### PR TITLE
add correct lower bound

### DIFF
--- a/get_bounds_others.py
+++ b/get_bounds_others.py
@@ -143,7 +143,8 @@ def get_layer_bound_LP(Ws,bs,UBs,LBs,x0,eps,p,neuron_states,nlayer,pred_label,ta
                 if p == "2" or p == "1":                
                     # transformation variable at z1 only
                     if p == "2":
-                        ztij = m.addVar(vtype=grb.GRB.CONTINUOUS, name="zt_"+str(i)+"_"+str(j))
+#                         ztij = m.addVar(vtype=grb.GRB.CONTINUOUS, name="zt_"+str(i)+"_"+str(j))
+                        ztij = m.addVar(vtype=grb.GRB.CONTINUOUS, lb = -np.inf, name="zt_"+str(i)+"_"+str(j))
                     elif p == "1":
                         ztij = m.addVar(vtype=grb.GRB.CONTINUOUS, lb=0, name="zt_"+str(i)+"_"+str(j))
                     zzts.append(ztij)  
@@ -226,7 +227,8 @@ def get_layer_bound_LP(Ws,bs,UBs,LBs,x0,eps,p,neuron_states,nlayer,pred_label,ta
          #finally, add constraints for z[1] and ztrans[1], the input
         temp = []
         for i in range(len(UBs[0])):
-            tempi = m.addVar(vtype=grb.GRB.CONTINUOUS)
+#             tempi = m.addVar(vtype=grb.GRB.CONTINUOUS)
+            tempi = m.addVar(vtype=grb.GRB.CONTINUOUS, lb=-np.inf)
             temp.append(tempi)
                     
         for i in range(len(UBs[0])):


### PR DESCRIPTION
Dear Lily,

I think there may be a bug in the code that implements linear programming method in the file get_bound_others.py

In the part where the linear-programming-full method is implemented. You create variable ztrans when the p==2 or p==1 to add the nonlinear constraint ||x-x_0||_p <= eps. When you create the variable  ztij in line 146 and tempi in line 229, you don't explicitly set the lower bounds of these variables. By default, Gurobi will use the default value, 0, as their lower bound. However, I think these variables have no reason to be non-negative.  I think you should manually set the lower bound of these variables to be -infinity. 

I tried to manually set the lower bound of these variables to be -infinity myself. After that, I did observe that  the lower and upper bounds given by linear programming become looser since the feasible region of the optimization problem becomes larger.

Could you please kindly help me verify if this is an error in the original code? Thanks for your attention!

Best,
Zhaoyang  